### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           yarn build
 
       - name: Docker release
-        uses: elgohr/Publish-Docker-Github-Action@main
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ismdeep/db-manager-web
           username: ismdeep


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore